### PR TITLE
Use add selected count API instead of score increment

### DIFF
--- a/Flow.Launcher.Plugin.VisualStudio.csproj
+++ b/Flow.Launcher.Plugin.VisualStudio.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flow.Launcher.Plugin" Version="4.1.0" />
+    <PackageReference Include="Flow.Launcher.Plugin" Version="4.5.0" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 

--- a/Main.cs
+++ b/Main.cs
@@ -19,8 +19,6 @@ namespace Flow.Launcher.Plugin.VisualStudio
         private IconProvider iconProvider;
         private Dictionary<Entry, List<int>> entryHighlightData;
 
-        private const int ScoreIncrement = 10000;
-
         public async Task InitAsync(PluginInitContext context)
         {
             this.context = context;
@@ -81,7 +79,7 @@ namespace Flow.Launcher.Plugin.VisualStudio
             if (string.IsNullOrWhiteSpace(query.Search))
             {
                 return plugin.RecentEntries.OrderBy(e => e.Value.LastAccessed)
-                                           .Select((e, i) => CreateEntryResult(e, i * ScoreIncrement))
+                                           .Select(CreateEntryResult)
                                            .ToList();
             }
 
@@ -110,6 +108,8 @@ namespace Flow.Launcher.Plugin.VisualStudio
                         Title = $"Open in \"{vs.DisplayName}\" [Version: {vs.DisplayVersion}]",
                         SubTitle = vs.ExePath,
                         IcoPath = iconProvider.GetIconPath(vs),
+                        Score = 2,
+                        AddSelectedCount = false,
                         Action = _ =>
                         {
                             context.API.ShellRun($"\"{currentEntry.Path}\"", $"\"{vs.ExePath}\"");
@@ -121,6 +121,8 @@ namespace Flow.Launcher.Plugin.VisualStudio
                     Title = $"Remove \"{selectedResult.Title}\" from recent items list.",
                     SubTitle = selectedResult.SubTitle,
                     IcoPath = IconProvider.Remove,
+                    Score = 1,
+                    AddSelectedCount = false,
                     AsyncAction = async _ =>
                     {
                         await plugin.RemoveEntry(currentEntry);
@@ -134,6 +136,8 @@ namespace Flow.Launcher.Plugin.VisualStudio
                     Title = $"Open in File Explorer",
                     SubTitle = currentEntry.Path,
                     IcoPath = IconProvider.Folder,
+                    Score = 0,
+                    AddSelectedCount = false,
                     Action = _ =>
                     {
                         context.API.OpenDirectory(Path.GetDirectoryName(currentEntry.Path), currentEntry.Path);
@@ -183,6 +187,7 @@ namespace Flow.Launcher.Plugin.VisualStudio
                 SubTitleToolTip = $"{e.Path}\n\nLast Accessed:\t{e.Value.LastAccessed:F}",
                 ContextData = e,
                 Score = score,
+                AddSelectedCount = false,
                 IcoPath = IconProvider.DefaultIcon,
                 Action = _ =>
                 {

--- a/Main.cs
+++ b/Main.cs
@@ -79,7 +79,7 @@ namespace Flow.Launcher.Plugin.VisualStudio
             if (string.IsNullOrWhiteSpace(query.Search))
             {
                 return plugin.RecentEntries.OrderBy(e => e.Value.LastAccessed)
-                                           .Select(CreateEntryResult)
+                                           .Select((e, i) => CreateEntryResult(e, i, false))
                                            .ToList();
             }
 
@@ -92,7 +92,7 @@ namespace Flow.Launcher.Plugin.VisualStudio
 
             return plugin.RecentEntries.Select(x => new EntryScore(x))
                                        .Where(x => searchFunc(x, query))
-                                       .Select(x => CreateEntryResult(x.Entry, x.Score))
+                                       .Select(x => CreateEntryResult(x.Entry, x.Score, true))
                                        .ToList();
         }
 
@@ -166,7 +166,7 @@ namespace Flow.Launcher.Plugin.VisualStudio
             };
         }
 
-        private Result CreateEntryResult(Entry e, int score)
+        private Result CreateEntryResult(Entry e, int score, bool addSelectedScore)
         {
             Action action = () => context.API.ShellRun($"\"{e.Path}\"");
             if (!string.IsNullOrWhiteSpace(settings.DefaultVSId))
@@ -187,7 +187,7 @@ namespace Flow.Launcher.Plugin.VisualStudio
                 SubTitleToolTip = $"{e.Path}\n\nLast Accessed:\t{e.Value.LastAccessed:F}",
                 ContextData = e,
                 Score = score,
-                AddSelectedCount = false,
+                AddSelectedCount = addSelectedScore,
                 IcoPath = IconProvider.DefaultIcon,
                 Action = _ =>
                 {

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ pm install Visual Studio Launcher
 ```
 in Flow Launcher.
 > [!IMPORTANT]
-> Requires at least Flow Launcher version 1.16.
+> Requires at least Flow Launcher version 1.20.
 
 ## Features
 ### Searching


### PR DESCRIPTION
- Use add selected count API instead of score increment to make sure ranking will never change
- Add selected count when querying something (users want to search sth so we should add selected count to improve ranking) and do not when querying text is empty (users are just checking the list so we should not add selected count)